### PR TITLE
add .gitignore and .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# This file is for zig-specific build artifacts.
+# If you have OS-specific or editor-specific files to ignore,
+# such as *.swp or .DS_Store, put those in your global
+# ~/.gitignore and put this in your ~/.gitconfig:
+#
+# [core]
+#     excludesfile = ~/.gitignore
+#
+# Cheers!
+# -andrewrk
+
+zig-cache/
+/release/
+/debug/
+/build/
+/build-*/
+/docgen_tmp/
+


### PR DESCRIPTION
This adds a `.gitignore` file (which is copied from the Zig repository, I use it in all my projects) to avoid committing the `zig-cache` directories by accident :)

I also copied the `.gitattributes` file from my [zig template repository](github.com/hexops/ztemplate), it ensures that people on Windows contributing to your repository always use `\n` LF instead of you potentially ending up with mixed `\n` LF, `\r\n` CRLF and `\r` CR in some cases.

Happy to alter this however you want, I just hate those `zig-cache` directories showing up in my commits by accident as I work on compression :)

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>