### PR TITLE
remove unused submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/trieton"]
-	path = src/trieton
-	url = https://github.com/jecolon/trieton.git


### PR DESCRIPTION
As far as I can tell, this is unused / not required to be cloned to use Ziglyph.

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>