### PR TITLE
Update for Zig package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,32 @@ This is pre-1.0 software. Although breaking changes are less frequent with each 
 they still will occur until we reach 1.0.
 
 ## Integrating Ziglyph in your Project
+### Zig Package Manager
+In a `build.zig.zon` file add the following to the dependencies object. Currently only tar.gz urls are supported.
+```zig
+.ziglyph = .{
+    .url = "https://github.com/jecolon/ziglyph/archive/<FULL COMMIT SHA>.tar.gz",
+    .hash = "sha2-256 hash of the tar.gz file",
+}
+```
+
+Then in your `build.zig` file add the following to the `exe` section for the executable where you wish to have Ziglyph available.
+```zig
+const ziglyph = b.dependency("ziglyph", .{
+    .target = target,
+    .optimize = optimize,
+});
+exe.addModule("ziglyph", ziglyph.module("ziglyph"));
+```
+
+Now in the code, you can import components like this:
+
+```zig
+const ziglyph = @import("ziglyph");
+const letter = @import("ziglyph").letter; // or const letter = ziglyph.letter;
+const number = @import("ziglyph").number; // or const number = ziglyph.number;
+```
+
 ### Using Zigmod
 
 ```sh
@@ -32,28 +58,6 @@ In the `exe` section for the executable where you wish to have Zigstr available,
 
 ```zig
 deps.addAllTo(exe);
-```
-
-### Manually via Git
-In a `libs` subdirectory under the root of your project, clone this repository via
-
-```sh
-$  git clone https://github.com/jecolon/ziglyph.git
-```
-
-Now in your build.zig, you can add:
-
-```zig
-exe.addPackagePath("ziglyph", "libs/ziglyph/src/ziglyph.zig");
-```
-
-to the `exe` section for the executable where you wish to have Ziglyph available. Now in the code, you
-can import components like this:
-
-```zig
-const ziglyph = @import("ziglyph");
-const letter = @import("ziglyph").letter; // or const letter = ziglyph.letter;
-const number = @import("ziglyph").number; // or const number = ziglyph.number;
 ```
 
 ### Using the `ziglyph` Namespace

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const number = @import("ziglyph").number; // or const number = ziglyph.number;
 ### Using Zigmod
 
 ```sh
-$ zigmod aq add 1/jecolon/zigstr
+$ zigmod aq add 1/jecolon/ziglyph
 $ zigmod fetch
 ```
 

--- a/build.zig
+++ b/build.zig
@@ -1,13 +1,27 @@
-const Builder = @import("std").build.Builder;
+const Build = @import("std").Build;
 
-pub fn build(b: *Builder) void {
-    const mode = b.standardReleaseOptions();
-    const lib = b.addStaticLibrary("ziglyph", "src/ziglyph.zig");
-    lib.setBuildMode(mode);
+pub fn build(b: *Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    b.addModule(.{
+        .name = "ziglyph",
+        .source_file = .{ .path = "src/ziglyph.zig" },
+    });
+
+    const lib = b.addStaticLibrary(.{
+        .name = "ziglyph",
+        .root_source_file = .{ .path = "src/ziglyph.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
     lib.install();
 
-    var main_tests = b.addTest("src/tests.zig");
-    main_tests.setBuildMode(mode);
+    var main_tests = b.addTest(.{
+        .root_source_file = .{ .path = "src/tests.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&main_tests.step);

--- a/src/ascii.zig
+++ b/src/ascii.zig
@@ -307,7 +307,7 @@ test "ascii character classes" {
 /// Caller owns returned string and must free with `allocator`.
 pub fn allocLowerString(allocator: std.mem.Allocator, ascii_string: []const u8) ![]u8 {
     const result = try allocator.alloc(u8, ascii_string.len);
-    for (result) |*c, i| {
+    for (result, 0..) |*c, i| {
         c.* = toLower(ascii_string[i]);
     }
     return result;
@@ -323,7 +323,7 @@ test "allocLowerString" {
 /// Caller owns returned string and must free with `allocator`.
 pub fn allocUpperString(allocator: std.mem.Allocator, ascii_string: []const u8) ![]u8 {
     const result = try allocator.alloc(u8, ascii_string.len);
-    for (result) |*c, i| {
+    for (result, 0..) |*c, i| {
         c.* = toUpper(ascii_string[i]);
     }
     return result;
@@ -338,7 +338,7 @@ test "allocUpperString" {
 /// Compares strings `a` and `b` case insensitively and returns whether they are equal.
 pub fn eqlIgnoreCase(a: []const u8, b: []const u8) bool {
     if (a.len != b.len) return false;
-    for (a) |a_c, i| {
+    for (a, 0..) |a_c, i| {
         if (toLower(a_c) != toLower(b[i])) return false;
     }
     return true;

--- a/src/collator/Collator.zig
+++ b/src/collator/Collator.zig
@@ -333,7 +333,7 @@ pub fn sortKey(self: Self, allocator: std.mem.Allocator, str: []const u8) ![]con
 
 /// Orders strings `a` and `b` based only on the base characters; case and combining marks are ignored.
 pub fn primaryOrder(a: []const u16, b: []const u16) std.math.Order {
-    return for (a) |weight, i| {
+    return for (a, 0..) |weight, i| {
         if (weight == 0) break .eq; // End of level
         const order = std.math.order(weight, b[i]);
         if (order != .eq) break order;
@@ -344,7 +344,7 @@ pub fn primaryOrder(a: []const u16, b: []const u16) std.math.Order {
 pub fn secondaryOrder(a: []const u16, b: []const u16) std.math.Order {
     var last_level = false;
 
-    return for (a) |weight, i| {
+    return for (a, 0..) |weight, i| {
         if (weight == 0) {
             if (last_level) break .eq else last_level = true;
             continue;
@@ -357,7 +357,7 @@ pub fn secondaryOrder(a: []const u16, b: []const u16) std.math.Order {
 
 /// Orders strings `a` and `b` based on base characters, combining marks, and letter case.
 pub fn tertiaryOrder(a: []const u16, b: []const u16) std.math.Order {
-    return for (a) |weight, i| {
+    return for (a, 0..) |weight, i| {
         const order = std.math.order(weight, b[i]);
         if (order != .eq) break order;
     } else .eq;
@@ -590,7 +590,7 @@ test "UCA tests" {
         if (order == .eq) {
             const len = if (prev_nfd.slice.len > current_nfd.slice.len) current_nfd.slice.len else prev_nfd.slice.len;
 
-            const tie_breaker = for (prev_nfd.slice[0..len]) |prev_cp, i| {
+            const tie_breaker = for (prev_nfd.slice[0..len], 0..) |prev_cp, i| {
                 const cp_order = std.math.order(prev_cp, current_nfd.slice[i]);
                 if (cp_order != .eq) break cp_order;
             } else .eq;

--- a/src/collator/Collator.zig
+++ b/src/collator/Collator.zig
@@ -33,7 +33,7 @@ pub fn init(allocator: std.mem.Allocator) !Self {
     // allkeys-strip.txt file.
     const ak_gz_file = @embedFile("../data/uca/allkeys-diffs.txt.gz");
     var ak_in_stream = std.io.fixedBufferStream(ak_gz_file);
-    var ak_gzip_stream = try std.compress.gzip.gzipStream(allocator, ak_in_stream.reader());
+    var ak_gzip_stream = try std.compress.gzip.decompress(allocator, ak_in_stream.reader());
     defer ak_gzip_stream.deinit();
 
     var ak_br = std.io.bufferedReader(ak_gzip_stream.reader());
@@ -516,7 +516,7 @@ test "UCA tests" {
 
     const uca_gz_file = try std.fs.cwd().openFile("src/data/uca/CollationTest_NON_IGNORABLE_SHORT.txt.gz", .{});
     defer uca_gz_file.close();
-    var uca_gzip_stream = try std.compress.gzip.gzipStream(allocator, uca_gz_file.reader());
+    var uca_gzip_stream = try std.compress.gzip.decompress(allocator, uca_gz_file.reader());
     defer uca_gzip_stream.deinit();
 
     var uca_br = std.io.bufferedReader(uca_gzip_stream.reader());

--- a/src/normalizer/Normalizer.zig
+++ b/src/normalizer/Normalizer.zig
@@ -318,7 +318,7 @@ fn nfxd(self: Self, allocator: std.mem.Allocator, str: []const u8, form: Form) !
     var cp_iter = view.iterator();
     while (cp_iter.nextCodepoint()) |cp| {
         const dc = self.decompose(cp, form);
-        const slice = for (dc.cps) |dcp, i| {
+        const slice = for (dc.cps, 0..) |dcp, i| {
             if (dcp == 0) break dc.cps[0..i];
         } else dc.cps[0..];
         try dcp_list.appendSlice(slice);
@@ -800,7 +800,7 @@ fn getLeadCcc(self: Self, cp: u21) u8 {
 
 fn getTrailCcc(self: Self, cp: u21) u8 {
     const dc = self.mapping(cp, .nfd);
-    const len = for (dc.cps) |dcp, i| {
+    const len = for (dc.cps, 0..) |dcp, i| {
         if (dcp == 0) break i;
     } else dc.cps.len;
     return ccc_map.combiningClass(dc.cps[len -| 1]);

--- a/src/normalizer/Normalizer.zig
+++ b/src/normalizer/Normalizer.zig
@@ -38,7 +38,7 @@ pub fn init(allocator: std.mem.Allocator) !Self {
     // Composites file.
     const comp_gz_file = @embedFile("../data/ucd/Composites.txt.gz");
     var comp_in_stream = std.io.fixedBufferStream(comp_gz_file);
-    var comp_gzip_stream = try std.compress.gzip.gzipStream(allocator, comp_in_stream.reader());
+    var comp_gzip_stream = try std.compress.gzip.decompress(allocator, comp_in_stream.reader());
     defer comp_gzip_stream.deinit();
 
     var comp_br = std.io.bufferedReader(comp_gzip_stream.reader());
@@ -57,7 +57,7 @@ pub fn init(allocator: std.mem.Allocator) !Self {
     // Decompositions file.
     const decomp_gz_file = @embedFile("../data/ucd/Decompositions.txt.gz");
     var decomp_in_stream = std.io.fixedBufferStream(decomp_gz_file);
-    var decomp_gzip_stream = try std.compress.gzip.gzipStream(allocator, decomp_in_stream.reader());
+    var decomp_gzip_stream = try std.compress.gzip.decompress(allocator, decomp_in_stream.reader());
     defer decomp_gzip_stream.deinit();
 
     var decomp_br = std.io.bufferedReader(decomp_gzip_stream.reader());
@@ -335,7 +335,7 @@ fn nfxd(self: Self, allocator: std.mem.Allocator, str: []const u8, form: Form) !
         dstr_list.appendSliceAssumeCapacity(buf[0..len]);
     }
 
-    return Result{ .allocator = allocator, .slice = dstr_list.toOwnedSlice() };
+    return Result{ .allocator = allocator, .slice = try dstr_list.toOwnedSlice() };
 }
 
 test "nfd ASCII / no-alloc" {
@@ -516,7 +516,7 @@ fn nfxc(self: Self, allocator: std.mem.Allocator, str: []const u8, form: Form) !
                 cstr_list.appendSliceAssumeCapacity(buf[0..len]);
             }
 
-            return Result{ .allocator = allocator, .slice = cstr_list.toOwnedSlice() };
+            return Result{ .allocator = allocator, .slice = try cstr_list.toOwnedSlice() };
         }
 
         // Otherwise update code points list.
@@ -598,7 +598,7 @@ test "UCD tests" {
                     try i_buf.appendSlice(cp_buf[0..len]);
                 }
 
-                input = i_buf.toOwnedSlice();
+                input = try i_buf.toOwnedSlice();
             } else if (field_index == 1) {
                 // NFC, time to test.
                 var w_buf = std.ArrayList(u8).init(allocator);

--- a/src/segmenter/Grapheme.zig
+++ b/src/segmenter/Grapheme.zig
@@ -175,14 +175,14 @@ pub fn StreamingGraphemeIterator(comptime T: type) type {
                 }
 
                 return Grapheme{
-                    .bytes = all_bytes.toOwnedSlice(),
+                    .bytes = try all_bytes.toOwnedSlice(),
                     .offset = 0,
                 };
             }
 
             if (cp == '\x0a' or gbp.isControl(cp)) {
                 return Grapheme{
-                    .bytes = all_bytes.toOwnedSlice(),
+                    .bytes = try all_bytes.toOwnedSlice(),
                     .offset = 0,
                 };
             }
@@ -246,7 +246,7 @@ pub fn StreamingGraphemeIterator(comptime T: type) type {
             }
 
             return Grapheme{
-                .bytes = all_bytes.toOwnedSlice(),
+                .bytes = try all_bytes.toOwnedSlice(),
                 .offset = 0,
             };
         }
@@ -341,7 +341,7 @@ test "Segmentation GraphemeIterator" {
             }
 
             try want.append(Grapheme{
-                .bytes = cp_bytes.toOwnedSlice(),
+                .bytes = try cp_bytes.toOwnedSlice(),
                 .offset = bytes_index,
             });
 
@@ -440,7 +440,7 @@ test "Segmentation StreamingGraphemeIterator" {
             }
 
             try want.append(Grapheme{
-                .bytes = cp_bytes.toOwnedSlice(),
+                .bytes = try cp_bytes.toOwnedSlice(),
                 .offset = bytes_index,
             });
 

--- a/src/segmenter/Sentence.zig
+++ b/src/segmenter/Sentence.zig
@@ -340,7 +340,7 @@ pub const SentenceIterator = struct {
 };
 
 // Predicates
-const TokenPredicate = std.meta.FnPtr(fn (Token) bool);
+const TokenPredicate = *const fn (Token) bool;
 
 fn isNumeric(token: Token) bool {
     return token.ty == .numeric;
@@ -450,7 +450,7 @@ test "Segmentation SentenceIterator" {
             }
 
             try want.append(Sentence{
-                .bytes = cp_bytes.toOwnedSlice(),
+                .bytes = try cp_bytes.toOwnedSlice(),
                 .offset = bytes_index,
             });
 

--- a/src/segmenter/Sentence.zig
+++ b/src/segmenter/Sentence.zig
@@ -93,7 +93,7 @@ pub const SentenceIterator = struct {
         self.start = self.tokens.items[0];
 
         // Set token offsets.
-        for (self.tokens.items) |*token, i| {
+        for (self.tokens.items, 0..) |*token, i| {
             token.offset = i;
         }
 
@@ -775,7 +775,7 @@ test "Segmentation ComptimeSentenceIterator" {
     ;
     const want = &[_][]const u8{ s1, s2 };
 
-    for (sentences) |sentence, i| {
+    for (sentences, 0..) |sentence, i| {
         try testing.expect(sentence.eql(want[i]));
     }
 }

--- a/src/segmenter/Word.zig
+++ b/src/segmenter/Word.zig
@@ -456,7 +456,7 @@ test "Segmentation WordIterator" {
             }
 
             try want.append(Word{
-                .bytes = cp_bytes.toOwnedSlice(),
+                .bytes = try cp_bytes.toOwnedSlice(),
                 .offset = bytes_index,
             });
 

--- a/src/tests/readme_tests.zig
+++ b/src/tests/readme_tests.zig
@@ -164,7 +164,7 @@ test "SentenceIterator" {
         }
     }
 
-    for (sentences) |sentence, j| {
+    for (sentences, 0..) |sentence, j| {
         try testing.expect(sentence.eql(want[j]));
     }
 }


### PR DESCRIPTION
Hi! I'm not sure if you want to merge this now or wait for more of the package manager APIs to stabilize, but this is all the changes required to update to `0.11.0-dev.1812+26196be34` and add support for the new Zig package manager.

A few notes
* `toOwnedSlice()` can now potentially fail, so I added `try` to all calls
* updated for loop syntax
* updated `build.zig` for new naming conventions and added a module
* updated the readme and replaced the git submodule instructions. I chose to put this above the zigmod instructions.

I separated this into separate commits, but I can combine them or separate them more if needed. I also ran all tests and verified the new module works in a dependent project.