### PR TITLE
Update to Zig 0.11.0-dev.3655+a2f54fce5

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,32 +182,32 @@ test "Collation" {
     var strings = [_][]const u8{ "def", "xyz", "abc" };
     var want = [_][]const u8{ "abc", "def", "xyz" };
 
-    std.sort.sort([]const u8, &strings, c, Collator.ascending);
+    std.mem.sort([]const u8, &strings, c, Collator.ascending);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 
     want = [_][]const u8{ "xyz", "def", "abc" };
-    std.sort.sort([]const u8, &strings, c, Collator.descending);
+    std.mem.sort([]const u8, &strings, c, Collator.descending);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 
     // Caseless sorting
     strings = [_][]const u8{ "def", "Abc", "abc" };
     want = [_][]const u8{ "Abc", "abc", "def" };
 
-    std.sort.sort([]const u8, &strings, c, Collator.ascendingCaseless);
+    std.mem.sort([]const u8, &strings, c, Collator.ascendingCaseless);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 
     want = [_][]const u8{ "def", "Abc", "abc" };
-    std.sort.sort([]const u8, &strings, c, Collator.descendingCaseless);
+    std.mem.sort([]const u8, &strings, c, Collator.descendingCaseless);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 
     // Caseless / markless sorting
     strings = [_][]const u8{ "ábc", "Abc", "abc" };
     want = [_][]const u8{ "ábc", "Abc", "abc" };
 
-    std.sort.sort([]const u8, &strings, c, Collator.ascendingBase);
+    std.mem.sort([]const u8, &strings, c, Collator.ascendingBase);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 
-    std.sort.sort([]const u8, &strings, c, Collator.descendingBase);
+    std.mem.sort([]const u8, &strings, c, Collator.descendingBase);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 }
 ```

--- a/build.zig
+++ b/build.zig
@@ -14,7 +14,7 @@ pub fn build(b: *Build) void {
         .target = target,
         .optimize = optimize,
     });
-    lib.install();
+    b.installArtifact(lib);
 
     var main_tests = b.addTest(.{
         .root_source_file = .{ .path = "src/tests.zig" },
@@ -22,6 +22,7 @@ pub fn build(b: *Build) void {
         .optimize = optimize,
     });
 
+    const run_tests = b.addRunArtifact(main_tests);
     const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&main_tests.step);
+    test_step.dependOn(&run_tests.step);
 }

--- a/src/ascii.zig
+++ b/src/ascii.zig
@@ -196,7 +196,7 @@ const combinedTable = init: {
             @as(u9, graph[i]) << @enumToInt(tIndex.Graph) |
             @as(u9, symbol[i]) << @enumToInt(tIndex.Symbol);
     }
-    std.mem.set(u9, table[128..256], 0);
+    @memset(table[128..256], 0);
     break :init table;
 };
 

--- a/src/collator/Collator.zig
+++ b/src/collator/Collator.zig
@@ -391,7 +391,7 @@ test "key order with combining" {
     try std.testing.expectEqual(std.math.Order.gt, tertiaryOrder(key_a, key_b));
 }
 
-/// An ascending sort for strings that works with `std.sort.sort`. Because the API requires this function to be
+/// An ascending sort for strings that works with `std.mem.sort`. Because the API requires this function to be
 /// infallible, it just returns `false` on errors.
 pub fn ascending(self: Self, a: []const u8, b: []const u8) bool {
     const key_a = self.sortKey(self.ducet.allocator, a) catch return false;
@@ -402,7 +402,7 @@ pub fn ascending(self: Self, a: []const u8, b: []const u8) bool {
     return tertiaryOrder(key_a, key_b) == .lt;
 }
 
-/// A descending sort for strings that works with `std.sort.sort`. Because the API requires this function to be
+/// A descending sort for strings that works with `std.mem.sort`. Because the API requires this function to be
 /// infallible, it just returns `false` on errors.
 pub fn descending(self: Self, a: []const u8, b: []const u8) bool {
     const key_a = self.sortKey(self.ducet.allocator, a) catch return false;
@@ -420,15 +420,15 @@ test "sort functions" {
     var strings = [_][]const u8{ "def", "xyz", "abc" };
     var want = [_][]const u8{ "abc", "def", "xyz" };
 
-    std.sort.sort([]const u8, &strings, c, ascending);
+    std.mem.sort([]const u8, &strings, c, ascending);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 
     want = [_][]const u8{ "xyz", "def", "abc" };
-    std.sort.sort([]const u8, &strings, c, descending);
+    std.mem.sort([]const u8, &strings, c, descending);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 }
 
-/// A caseless ascending sort for strings that works with `std.sort.sort`. Because the API requires this function to be
+/// A caseless ascending sort for strings that works with `std.mem.sort`. Because the API requires this function to be
 /// infallible, it just returns `false` on errors.
 pub fn ascendingCaseless(self: Self, a: []const u8, b: []const u8) bool {
     const key_a = self.sortKey(self.ducet.allocator, a) catch return false;
@@ -439,7 +439,7 @@ pub fn ascendingCaseless(self: Self, a: []const u8, b: []const u8) bool {
     return secondaryOrder(key_a, key_b) == .lt;
 }
 
-/// A caseless descending sort for strings that works with `std.sort.sort`. Because the API requires this function to be
+/// A caseless descending sort for strings that works with `std.mem.sort`. Because the API requires this function to be
 /// infallible, it just returns `false` on errors.
 pub fn descendingCaseless(self: Self, a: []const u8, b: []const u8) bool {
     const key_a = self.sortKey(self.ducet.allocator, a) catch return false;
@@ -457,11 +457,11 @@ test "caseless sort functions" {
     var strings = [_][]const u8{ "def", "Abc", "abc" };
     var want = [_][]const u8{ "Abc", "abc", "def" };
 
-    std.sort.sort([]const u8, &strings, c, ascendingCaseless);
+    std.mem.sort([]const u8, &strings, c, ascendingCaseless);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 
     want = [_][]const u8{ "def", "Abc", "abc" };
-    std.sort.sort([]const u8, &strings, c, descendingCaseless);
+    std.mem.sort([]const u8, &strings, c, descendingCaseless);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 }
 
@@ -472,14 +472,14 @@ test "caseless / markless sort functions" {
     var strings = [_][]const u8{ "ábc", "Abc", "abc" };
     const want = [_][]const u8{ "ábc", "Abc", "abc" };
 
-    std.sort.sort([]const u8, &strings, c, ascendingBase);
+    std.mem.sort([]const u8, &strings, c, ascendingBase);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 
-    std.sort.sort([]const u8, &strings, c, descendingBase);
+    std.mem.sort([]const u8, &strings, c, descendingBase);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 }
 
-/// An ascending sort for strings that works with `std.sort.sort`. This ignores case and any combining marks like
+/// An ascending sort for strings that works with `std.mem.sort`. This ignores case and any combining marks like
 /// accents.  Because the API requires this function to be infallible, it just returns `false` on errors.
 pub fn ascendingBase(self: Self, a: []const u8, b: []const u8) bool {
     const key_a = self.sortKey(self.ducet.allocator, a) catch return false;
@@ -490,7 +490,7 @@ pub fn ascendingBase(self: Self, a: []const u8, b: []const u8) bool {
     return primaryOrder(key_a, key_b) == .lt;
 }
 
-/// A descending sort for strings that works with `std.sort.sort`. This ignores case and any combining marks like
+/// A descending sort for strings that works with `std.mem.sort`. This ignores case and any combining marks like
 /// accents.  Because the API requires this function to be infallible, it just returns `false` on errors.
 pub fn descendingBase(self: Self, a: []const u8, b: []const u8) bool {
     const key_a = self.sortKey(self.ducet.allocator, a) catch return false;

--- a/src/normalizer/Normalizer.zig
+++ b/src/normalizer/Normalizer.zig
@@ -293,7 +293,7 @@ fn canonicalSort(cps: []u21) void {
     while (i < cps.len) : (i += 1) {
         var start: usize = i;
         while (i < cps.len and ccc_map.combiningClass(cps[i]) != 0) : (i += 1) {}
-        std.sort.sort(u21, cps[start..i], {}, cccLess);
+        std.mem.sort(u21, cps[start..i], {}, cccLess);
     }
 }
 

--- a/src/segmenter/Sentence.zig
+++ b/src/segmenter/Sentence.zig
@@ -759,7 +759,7 @@ test "Segmentation ComptimeSentenceIterator" {
     ;
     comptime var ct_iter = ComptimeSentenceIterator(input){};
     const n = comptime ct_iter.count();
-    var sentences: [n]Sentence = undefined;
+    comptime var sentences: [n]Sentence = undefined;
     comptime {
         var i: usize = 0;
         while (ct_iter.next()) |sentence| : (i += 1) {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -13,7 +13,7 @@ test "Segmentation" {
     _ = @import("ziglyph.zig").Sentence;
 }
 
-test "ziglyph" {
+test "ziglyph categories" {
     _ = @import("ziglyph.zig").letter;
     _ = @import("ziglyph.zig").mark;
     _ = @import("ziglyph.zig").number;

--- a/src/tests/readme_tests.zig
+++ b/src/tests/readme_tests.zig
@@ -156,7 +156,7 @@ test "SentenceIterator" {
 
     comptime var ct_iter = ComptimeSentenceIterator(input){};
     const n = comptime ct_iter.count();
-    var sentences: [n]Sentence = undefined;
+    comptime var sentences: [n]Sentence = undefined;
     comptime {
         var ct_i: usize = 0;
         while (ct_iter.next()) |sentence| : (ct_i += 1) {
@@ -225,32 +225,32 @@ test "Collation" {
     var strings = [_][]const u8{ "def", "xyz", "abc" };
     var want = [_][]const u8{ "abc", "def", "xyz" };
 
-    std.sort.sort([]const u8, &strings, c, Collator.ascending);
+    std.mem.sort([]const u8, &strings, c, Collator.ascending);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 
     want = [_][]const u8{ "xyz", "def", "abc" };
-    std.sort.sort([]const u8, &strings, c, Collator.descending);
+    std.mem.sort([]const u8, &strings, c, Collator.descending);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 
     // Caseless sorting
     strings = [_][]const u8{ "def", "Abc", "abc" };
     want = [_][]const u8{ "Abc", "abc", "def" };
 
-    std.sort.sort([]const u8, &strings, c, Collator.ascendingCaseless);
+    std.mem.sort([]const u8, &strings, c, Collator.ascendingCaseless);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 
     want = [_][]const u8{ "def", "Abc", "abc" };
-    std.sort.sort([]const u8, &strings, c, Collator.descendingCaseless);
+    std.mem.sort([]const u8, &strings, c, Collator.descendingCaseless);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 
     // Caseless / markless sorting
     strings = [_][]const u8{ "ábc", "Abc", "abc" };
     want = [_][]const u8{ "ábc", "Abc", "abc" };
 
-    std.sort.sort([]const u8, &strings, c, Collator.ascendingBase);
+    std.mem.sort([]const u8, &strings, c, Collator.ascendingBase);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 
-    std.sort.sort([]const u8, &strings, c, Collator.descendingBase);
+    std.mem.sort([]const u8, &strings, c, Collator.descendingBase);
     try std.testing.expectEqualSlices([]const u8, &want, &strings);
 }
 


### PR DESCRIPTION
Updates for new build.zig API and standard library changes.

* `std.sort.sort` -> `std.mem.sort`
* `comptime var`
* use `b.installArtfact()` and other `build.zig` changes
* `std.mem.set()` -> `@memset()`
* Rename a duplicate test name